### PR TITLE
[feature.enable_restart] flag name error fix

### DIFF
--- a/AutoSplitter/auto_split.cpp
+++ b/AutoSplitter/auto_split.cpp
@@ -53,7 +53,7 @@ void LoadSettings(chrono::milliseconds &split_span,bool &enabled_stop,bool &enab
 
 	int hour, min, sec;
 	enabled_stop = conf.get<bool>("feature.enable_stop");
-	enabled_restart = conf.get<bool>("feature.enable_stop");
+	enabled_restart = conf.get<bool>("feature.enable_restart");
 	hour = conf.get<int>("split_timespan.hours");
 	min  = conf.get<int>("split_timespan.minutes");
 	sec  = conf.get<int>("split_timespan.seconds");


### PR DESCRIPTION
Hello Ifumiya,

I have found the plug-in unable to disable restart. I think it is same error as #1.  Sorry I am unable to test this fix yet. Will try confirm again when I am able to test.

Best regards,
Andrew